### PR TITLE
fix: set right aria label for start and end date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-airbnb-style-datepicker",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-airbnb-style-datepicker",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-airbnb-style-datepicker",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "A VueJs version of the popular AirBnb datepicker",
   "main": "dist/vue-airbnb-style-datepicker.cjs.js",
   "module": "dist/vue-airbnb-style-datepicker.es.js",

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -598,7 +598,7 @@ export default {
 
       if (isSelected) {
         if (this.isRangeMode) {
-          if (this.dateOne === this.selectedDate1) {
+          if (date === this.selectedDate1) {
             return this.ariaLabels.selectedStartDate(dateLabel)
           } else {
             return this.ariaLabels.selectedEndDate(dateLabel)


### PR DESCRIPTION
This allows ARIA labels `Selected ${date} as your start date.` for date1 and `Selected ${date} as your end date.` for date2 when using the date picker in range mode. Previously, it got confused and said `Selected ${date} as your start date.` even for the end date.